### PR TITLE
add missing dependency: more-itertools

### DIFF
--- a/mwpersistence/__init__.py
+++ b/mwpersistence/__init__.py
@@ -1,6 +1,6 @@
 from .token import Token
 from .state import State, DiffState
 
-__version__ = "0.2.4"
+__version__ = "0.2.5"
 
 __all__ = [Token, State, DiffState]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ mwcli
 mwxml
 deltas
 para
+more-itertools

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def requirements(fname):
 
 setup(
     name="mwpersistence",
-    version="0.2.4",  # see mwpersistence/__init__.py
+    version="0.2.5",  # see mwpersistence/__init__.py
     author="Aaron Halfaker",
     author_email="ahalfaker@wikimedia.org",
     description="A set of utilities for measuring content persistence and " +


### PR DESCRIPTION
It's used in `diffs2persistence` to use `peekable`